### PR TITLE
Fix syntax error in ADR template

### DIFF
--- a/decisions/adr-template-short.md
+++ b/decisions/adr-template-short.md
@@ -5,7 +5,6 @@ date: → YYYY-MM-DD indicating when the decision was last updated
 deciders: → list everyone involved in the decision
 consulted: → list everyone whose opinions are sought (typically, subject matter experts); and with whom there is two-way communication
 informed: → list everyone who is kept up-to-date on progress; and with whom there is one-way communication
----d: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
 ---
 # {short title of solved problem and solution}
 

--- a/decisions/adr-template-short.md
+++ b/decisions/adr-template-short.md
@@ -1,9 +1,11 @@
 ---
-status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}
-date: {YYYY-MM-DD when the decision was last updated}
-deciders: {list everyone involved in the decision}
-consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
-informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+# Update these YAML values so they describe this decision. Delete the leading `→` characters.
+status: → proposed | rejected | accepted | deprecated | … | superseded by [ADR-00XX](./0001-improve-connection-between-home-page-and-products.md)
+date: → YYYY-MM-DD indicating when the decision was last updated
+deciders: → list everyone involved in the decision
+consulted: → list everyone whose opinions are sought (typically, subject matter experts); and with whom there is two-way communication
+informed: → list everyone who is kept up-to-date on progress; and with whom there is one-way communication
+---d: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
 ---
 # {short title of solved problem and solution}
 

--- a/decisions/adr-template.md
+++ b/decisions/adr-template.md
@@ -1,9 +1,10 @@
 ---
-status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}
-date: {YYYY-MM-DD when the decision was last updated}
-deciders: {list everyone involved in the decision}
-consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
-informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+# Update these YAML values so they describe this decision. Delete the leading `→` characters.
+status: → proposed | rejected | accepted | deprecated | … | superseded by [ADR-00XX](./0001-improve-connection-between-home-page-and-products.md)
+date: → YYYY-MM-DD indicating when the decision was last updated
+deciders: → list everyone involved in the decision
+consulted: → list everyone whose opinions are sought (typically, subject matter experts); and with whom there is two-way communication
+informed: → list everyone who is kept up-to-date on progress; and with whom there is one-way communication
 ---
 # {short title of solved problem and solution}
 


### PR DESCRIPTION
Previously, GitHub was displaying a syntax error message to the person viewing the ADR template.

```
Error in user YAML: (<unknown>): did not find expected ',' or '}' while parsing a flow mapping at line 1 column 9
```

Removing the `[...](...)` Markdown hyperlink from the first line would have been sufficient to resolve this particular syntax error; but we would still be using the `{` and `}` characters to delimit a placeholder for the person editing the ADR, instead of to delimit a mapping of key-value pairs (which is what the YAML parser expects us to use them to do).

In this branch, I have replaced the `{` and `}` characters with:
- An instructional comment that appears in the source code view, but not the rendered view
- A leading `→` character in front of each "TODO" item

Here's a screenshot showing the rendered view of the ADR template, before and after this change was made.

![image](https://github.com/user-attachments/assets/7eece7d6-dc55-4d5c-9ddf-d5c41e5b15e3)
