### PR TITLE
Upgrade and pin third-party actions using commit hashes

### DIFF
--- a/.github/workflows/add-metab-issues-to-project.yml
+++ b/.github/workflows/add-metab-issues-to-project.yml
@@ -10,7 +10,7 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'metab_data_processing')
     steps:
       - name: Add issue to project
-        uses: actions/add-to-project@v0.5.0
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/microbiomedata/projects/178
           github-token: ${{ secrets.ORG_PROJECT_TOKEN }}


### PR DESCRIPTION
These changes implement the recommend security hardening step of [pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) using commit hashes. They also do an upgrade to avoid using [deprecated Node 20 actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

---

Implementation note: these changes were automatically generated with [pinact](https://github.com/suzuki-shunsuke/pinact):
```
pinact run --update --min-age 7
```